### PR TITLE
fix speedtest

### DIFF
--- a/speedTest.py
+++ b/speedTest.py
@@ -10,7 +10,7 @@ count = len(solutions)
 print(f"\rFinished {BLUE}0/{count} {RESET}tests",end="")
 data = {}
 for ind,sol in enumerate(solutions):
-    testcases = json.load(open(f"cases/{sol}.json","r"))
+    testcases = json.load(open(f"cases/{sol[:-4]}.json","r"))
     maxT = 0
     for case in testcases:
         input = case["input"]


### PR DESCRIPTION
When using the original:
testcases = json.load(open(f"cases/{sol}.json","r"))
{sol}.json will not create the string "problem_name.json" but instead it will create "problem_name.exe.json"
The extra .exe causes an error
For example, when sol = "AMC.exe"
It will attempt to open "cases/AMC.exe.json" instead of the correct "cases/AMC.json" 